### PR TITLE
Update yum_url for RedHat to a more stable scheme

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,3 @@
 ---
-influxdb_yum_url: https://repos.influxdata.com/rhel/$releasever/$basearch/stable
+influxdb_yum_url: https://repos.influxdata.com/rhel/{{ ansible_distribution_major_version }}/$basearch/stable
 influxdb_yum_key: https://repos.influxdata.com/influxdb.key


### PR DESCRIPTION
Non-RedHat OSes may differ in terms for `$releasever`, and using the Ansible fact might be more safe.

Example for OEL7: `7.9-6.0.1.el7_9`

Even RedHat uses `7Server` here...